### PR TITLE
Allow linking to system ntdll

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,15 @@
+use std::env::var;
+
 fn main() {
     #[cfg(feature = "user")] {
         if std::env::var("TARGET").map(
             |t| t == "x86_64-pc-windows-gnu" || t == "i686-pc-windows-gnu"
         ).unwrap_or(false) {
-            println!("cargo:rustc-link-lib=winapi_ntdll");
+            if var("WINAPI_NO_BUNDLED_LIBRARIES").is_ok() {
+                println!("cargo:rustc-link-lib=ntdll");
+            } else {
+                println!("cargo:rustc-link-lib=winapi_ntdll");
+            }
         }
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -2,7 +2,7 @@ use std::env::var;
 
 fn main() {
     #[cfg(feature = "user")] {
-        if std::env::var("TARGET").map(
+        if var("TARGET").map(
             |t| t == "x86_64-pc-windows-gnu" || t == "i686-pc-windows-gnu"
         ).unwrap_or(false) {
             if var("WINAPI_NO_BUNDLED_LIBRARIES").is_ok() {


### PR DESCRIPTION
Currently building with `WINAPI_NO_BUNDLED_LIBRARIES` fails with this error: `lld: error: unable to find library -lwinapi_ntdll`.

This PR fixes it by linking to system library in that case, similarly to wianpi: https://github.com/retep998/winapi-rs/blob/785f7f30a69c70687864ac650aebc123e942c1b3/build.rs#L494-L502