### PR TITLE
Fix temporary references for volatile read

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ environment:
     - host: i686-pc-windows-gnu
       channel: nightly
     - host: x86_64-pc-windows-gnu
-      channel: 1.33.0
+      channel: 1.64.0
     - host: i686-pc-windows-gnu
-      channel: 1.33.0
+      channel: 1.64.0
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/src/ntexapi.rs
+++ b/src/ntexapi.rs
@@ -1,4 +1,6 @@
 use core::mem::uninitialized;
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+use core::ptr::addr_of;
 use core::ptr::read_volatile;
 #[cfg(target_arch = "x86")]
 use core::sync::atomic::spin_loop_hint;
@@ -2780,7 +2782,7 @@ pub const USER_SHARED_DATA: *const KUSER_SHARED_DATA = 0x7ffe0000 as *const _;
 pub unsafe fn NtGetTickCount64() -> ULONGLONG {
     let mut tick_count: ULARGE_INTEGER = uninitialized();
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
-        *tick_count.QuadPart_mut() = read_volatile(&(*USER_SHARED_DATA).u.TickCountQuad);
+        *tick_count.QuadPart_mut() = read_volatile(addr_of!((*USER_SHARED_DATA).u.TickCountQuad));
     }
     #[cfg(target_arch = "x86")] {
         loop {
@@ -2804,7 +2806,7 @@ pub unsafe fn NtGetTickCount64() -> ULONGLONG {
 #[inline]
 pub unsafe fn NtGetTickCount() -> ULONG {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))] {
-        ((read_volatile(&(*USER_SHARED_DATA).u.TickCountQuad)
+        ((read_volatile(addr_of!((*USER_SHARED_DATA).u.TickCountQuad))
             * (*USER_SHARED_DATA).TickCountMultiplier as u64) >> 24) as u32
     }
     #[cfg(target_arch = "x86")] {


### PR DESCRIPTION
Taking a reference to an unaligned field is an undefined behavior, even if it is converted to a pointer immediately. Although the memory access here must be aligned given the fixed base address and the offset of the field, rustc still issue a warning due to the struct being 4 packed. Here we can use `core::ptr::addr_of` to create a pointer to a field without introducing a reference.

Fixes #11.