### PR TITLE
Bump Rust toolchain version for CI to 1.64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,9 @@ environment:
     - host: i686-pc-windows-gnu
       channel: nightly
     - host: x86_64-pc-windows-gnu
-      channel: 1.33.0
+      channel: 1.64.0
     - host: i686-pc-windows-gnu
-      channel: 1.33.0
+      channel: 1.64.0
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe


### PR DESCRIPTION
This aims to unblock #12 .

Since `core::ptr::addr_of` is not stablized until Rust 1.51, the current toolchain version used in appveyor is too old to build. According to the MSVC policy for this project i.e. `Always the latest stable`, we can update the specified version to let CI pass.