### PR TITLE
Change FIELD_OFFSET macro to remove requirement for `unaligned_references`

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -29,17 +29,8 @@ macro_rules! EXTERN {
 macro_rules! FIELD_OFFSET {
     ($_type:ty, $field:ident$(.$cfields:ident)*) => {
         unsafe {
-            union Transmuter<T: 'static> {
-                p: *const T,
-                r: &'static T,
-                i: usize,
-            }
-            #[allow(unaligned_references)]
-            Transmuter {
-                r: &(&Transmuter {
-                    p: $crate::_core::ptr::null::<$_type>()
-                }.r).$field$(.$cfields)*
-            }.i
+            let base = ::core::mem::MaybeUninit::<$_type>::uninit().as_ptr();
+            ::core::ptr::addr_of!((*base).$field$(.$cfields)*) as usize - base as usize
         }
     };
 }


### PR DESCRIPTION
`unaligned_references` is made into a hard error as per rust-lang/rust#102513 which will cause the FIELD_OFFSET macro to fail for packed structs. rust-lang/rfcs#3308 looks to implement this in core::mem however in the meantime this change passes all tests in [layout_x86_64.rs](https://github.com/MSxDOS/ntapi/blob/a09a60cbccf4ad3d05d80d076ecf5e375a5826b4/tests/layout_x86_64.rs) on rustc 1.70.0-nightly (900c35403 2023-03-08)