### PR TITLE
link ntdll on non-windows-gnu targets (needed for aarch64-pc-windows-gnullvm)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,8 @@ fn main() {
             } else {
                 println!("cargo:rustc-link-lib=winapi_ntdll");
             }
+        } else {
+            println!("cargo:rustc-link-lib=ntdll");
         }
     }
 }


### PR DESCRIPTION
See also msys2/MINGW-packages#17426.  On that, @mati865 suggested that there should be a check to avoid linking ntdll on msvc targets, but I am not sure.  winapi has logic in its build.rs to *prefix* lib names only for i686-pc-windows-gnu or x86_64-pc-windows-gnu, only if WINAPI_NO_BUNDLED_LIBRARIES is not set, but it still links the (unprefixed) libraries on any other target, so I am trying to replicate that here.  Let me know if that breaks msvc, and I can try adding an additional check.

Note I don't really know rust, so there may be a more elegant way to write this.